### PR TITLE
Add missing license and copyright attributions

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -7,28 +7,560 @@ Source: https://github.com/gardener/<repo name>
 # source code
 
 Files:
+  .ci/*
   .github/*
   .gitignore
+  charts/gardener-extension-shoot-networking-filter/.helmignore
+  charts/gardener-extension-shoot-networking-filter/templates/_helpers.tpl
+  charts/gardener-extension-shoot-networking-filter/templates/secret-oauth2.yaml
   CODEOWNERS
   go.mod
   go.sum
+  hack/api-reference/config.json
+  vendor/modules.txt
   VERSION
-Copyright: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+Copyright: 2022 SAP SE or an SAP affiliate company and Gardener contributors
 License: Apache-2.0
 
 # --------------------------------------------------
 # documentation
 
 Files:
-  CONTRIBUTING.md
-  README.md
-Copyright: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+  *.md
+  docs/*
+Copyright: 2022 SAP SE or an SAP affiliate company and Gardener contributors
 License: CC-BY-4.0
 
 # --------------------------------------------------
 # source dependencies
 
-# UNDER CONSTRUCTION
-# Files: vendor/github.com/example/dependency/*
-# Copyright: <copyright statement of dependency>
-# License: <SPDX license identifier of dependency>
+Files: vendor/github.com/ahmetb/gen-crd-api-reference-docs/*
+Copyright: n/a
+License: Apache-2.0
+
+Files: vendor/github.com/beorn7/perks/*
+Copyright: Copyright 2012-2015 The Prometheus Authors
+Copyright: Copyright 2013-2015 Blake Mizerany, Bjorn Rabenstein
+Copyright: Copyright 2010 The Go Authors
+Copyright: Copyright 2013 Matt T. Proud
+License: MIT
+
+Files: vendor/github.com/bronze1man/yaml2json/*
+Copyright: n/a
+License: MIT
+
+Files: vendor/github.com/BurntSushi/toml/*
+Copyright: Copyright (c) 2013 TOML authors
+License: MIT and BSD-3-Clause
+
+Files: vendor/github.com/cespare/xxhash/v2/*
+Copyright: Copyright (c) 2016 Caleb Spare
+License: MIT
+
+Files: vendor/github.com/cyphar/filepath-securejoin/*
+Copyright: Copyright (c) 2014-2015 Docker Inc & Go Authors
+Copyright: Copyright (c) 2017 SUSE LLC.
+License: BSD-3-Clause
+
+Files: vendor/github.com/davecgh/go-spew/*
+Copyright: Copyright (c) 2015-2016 Dave Collins
+License: ISC
+
+Files: vendor/github.com/dsnet/compress/*
+Copyright: Copyright (c) 2015, Joe Tsai and The Go Authors
+License: BSD-3-Clause
+
+Files: vendor/github.com/emicklei/go-restful/*
+Copyright: Copyright 2013 Ernest Micklei
+License: MIT
+
+Files: vendor/github.com/evanphx/json-patch/*
+Copyright: Copyright (c) 2014, Evan Phoenix
+License: BSD-3-Clause
+
+Files: vendor/github.com/fatih/color/*
+Copyright: Copyright (c) 2013 Fatih Arslan
+License: MIT
+
+Files: vendor/github.com/fsnotify/fsnotify/*
+Copyright: Copyright (c) 2012 The Go Authors
+Copyright: Copyright (c) 2012-2019 fsnotify Authors
+License: BSD-3-Clause
+
+Files: vendor/github.com/gardener/etcd-druid/*
+Copyright: Copyright (c) 2019 SAP SE or an SAP affiliate company
+License: Apache-2.0
+
+Files: vendor/github.com/gardener/external-dns-management/*
+Copyright: Copyright (c) 2019 SAP SE or an SAP affiliate company
+License: Apache-2.0
+
+Files: vendor/github.com/gardener/gardener/*
+Copyright: Copyright (c) 2019 SAP SE or an SAP affiliate company
+License: Apache-2.0
+
+Files: vendor/github.com/gardener/hvpa-controller/*
+Copyright: Copyright (c) 2019 SAP SE or an SAP affiliate company
+License: Apache-2.0
+
+Files: vendor/github.com/gardener/machine-controller-manager/*
+Copyright: Copyright (c) 2019 SAP SE or an SAP affiliate company
+License: Apache-2.0
+
+Files: vendor/github.com/ghodss/yaml/*
+Copyright: Copyright (c) 2014 Sam Ghods
+Copyright: Copyright (c) 2012 The Go Authors
+License: MIT and BSD-3-Clause
+
+Files: vendor/github.com/go-logr/logr/*
+Copyright: Copyright 2020 The logr
+License: Apache-2.0
+
+Files: vendor/github.com/go-logr/zapr/*
+Copyright: Copyright 2019 The logr
+Copyright: Copyright 2018 Solly Ross
+License: Apache-2.0
+
+Files: vendor/github.com/go-openapi/jsonpointer/*
+Copyright: Copyright 2013 sigu-399 https://github.com/sigu-399
+License: Apache-2.0
+
+Files: vendor/github.com/go-openapi/jsonreference/*
+Copyright: Copyright 2013 sigu-399 https://github.com/sigu-399
+License: Apache-2.0
+
+Files: vendor/github.com/go-openapi/swag/*
+Copyright: Copyright 2015 go-swagger
+License: Apache-2.0
+
+Files: vendor/github.com/gobuffalo/flect/*
+Copyright: Copyright (c) 2019 Mark Bates
+License: MIT
+
+Files: vendor/github.com/gobwas/glob/*
+Copyright: Copyright (c) 2016 Sergey Kamardin
+License: MIT
+
+Files: vendor/github.com/gogo/protobuf/*
+Copyright: Copyright 2015 The Go Authors
+License: BSD-3-Clause
+
+Files: vendor/github.com/golang/groupcache/*
+Copyright: Copyright 2013 Google Inc.
+License: Apache-2.0
+
+Files: vendor/github.com/golang/mock/*
+Copyright: Copyright 2010 Google Inc.
+License: Apache-2.0
+
+Files: vendor/github.com/golang/protobuf/*
+Copyright: Copyright 2010 The Go Authors
+License: BSD-3-Clause
+
+Files: vendor/github.com/golang/snappy/*
+Copyright: Copyright 2016 The Go Authors
+License: BSD-3-Clause
+
+Files: vendor/github.com/google/go-cmp/*
+Copyright: Copyright 2017, The Go Authors
+License: BSD-3-Clause
+
+Files: vendor/github.com/google/gofuzz/*
+Copyright: Copyright 2014 Google Inc.
+License: Apache-2.0
+
+Files: vendor/github.com/google/uuid/*
+Copyright: Copyright (c) 2009,2014 Google Inc.
+License: BSD-3-Clause
+
+Files: vendor/github.com/googleapis/gnostic/*
+Copyright: Copyright 2017 Google LLC.
+License: Apache-2.0
+
+Files: vendor/github.com/hashicorp/errwrap/*
+Copyright: n/a
+License: MPL-2.0
+
+Files: vendor/github.com/hashicorp/go-multierror/*
+Copyright: Copyright 2017 The Kubernetes Authors
+License: MPL-2.0
+
+Files: vendor/github.com/hashicorp/hcl/*
+Copyright: n/a
+License: MPL-2.0
+
+Files: vendor/github.com/huandu/xstrings/*
+Copyright: Copyright 2015 Huan Du
+License: MIT
+
+Files: vendor/github.com/imdario/mergo/*
+Copyright: Copyright 2013 Dario Castane
+Copyright: Copyright 2009 The Go Authors
+License: BSD-3-Clause
+
+Files: vendor/github.com/inconshreveable/mousetrap/*
+Copyright: Copyright 2014 Alan Shreve
+License: Apache-2.0
+
+Files: vendor/github.com/josharian/intern/*
+Copyright: Copyright (c) 2019 Josh Bleecher Snyder
+License: MIT
+
+Files: vendor/github.com/json-iterator/go/*
+Copyright: Copyright (c) 2016 json-iterator
+License: MIT
+
+Files: vendor/github.com/kubernetes-csi/external-snapshotter/v2/*
+Copyright: Copyright 2018 The Kubernetes Authors
+License: Apache-2.0
+
+Files: vendor/github.com/magiconair/properties/*
+Copyright: Copyright (c) 2013-2020, Frank Schroeder
+License: BSD-2-Clause
+
+Files: vendor/github.com/mailru/easyjson/*
+Copyright: Copyright (c) 2016 Mail.Ru Group
+License: MIT
+
+Files: vendor/github.com/Masterminds/goutils/*
+Copyright: Copyright 2014 Alexander Okoli
+License: Apache-2.0
+
+Files: vendor/github.com/Masterminds/semver/*
+Copyright: Copyright (c) 2014-2019, Matt Butcher and Matt Farina
+License: MIT
+
+Files: vendor/github.com/Masterminds/sprig/*
+Copyright: Copyright (c) 2013 Masterminds
+License: MIT
+
+Files: vendor/github.com/mattn/go-colorable/*
+Copyright: Copyright (c) 2016 Yasuhiro Matsumoto
+License: MIT
+
+Files: vendor/github.com/mattn/go-isatty/*
+Copyright: Copyright (c) Yasuhiro MATSUMOTO
+License: MIT
+
+Files: vendor/github.com/matttproud/golang_protobuf_extensions/*
+Copyright: Copyright 2012 Matt T. Proud (matt.proud@gmail.com)
+License: Apache-2.0
+
+Files: vendor/github.com/mholt/archiver/*
+Copyright: Copyright (c) 2016 Matthew Holt
+License: MIT
+
+Files: vendor/github.com/mitchellh/copystructure/*
+Copyright: Copyright (c) 2014 Mitchell Hashimoto
+License: MIT
+
+Files: vendor/github.com/mitchellh/mapstructure/*
+Copyright: Copyright (c) 2013 Mitchell Hashimoto
+License: MIT
+
+Files: vendor/github.com/mitchellh/reflectwalk/*
+Copyright: Copyright (c) 2013 Mitchell Hashimoto
+License: MIT
+
+Files: vendor/github.com/moby/spdystream/*
+Copyright: Copyright 2014-2021 Docker Inc.
+License: Apache-2.0
+
+Files: vendor/github.com/modern-go/concurrent/*
+Copyright: n/a
+License: Apache-2.0
+
+Files: vendor/github.com/modern-go/reflect2/*
+Copyright: n/a
+License: Apache-2.0
+
+Files: vendor/github.com/nwaples/rardecode/*
+Copyright: Copyright (c) 2015, Nicholas Waples
+License: BSD-2-Clause
+
+Files: vendor/github.com/nxadm/tail/*
+Copyright: Copyright (c) 2019 FOSS contributors
+Copyright: Copyright (c) 2015 HPE Software Inc.
+Copyright: Copyright (c) 2013 ActiveState Software Inc.
+License: MIT
+
+Files: vendor/github.com/onsi/ginkgo/*
+Copyright: Copyright (c) 2013-2014 Onsi Fakhouri
+License: MIT
+
+Files: vendor/github.com/onsi/gomega/*
+Copyright: n/a
+License: MIT
+
+Files: vendor/github.com/pelletier/go-toml/*
+Copyright: Copyright (c) 2013 - 2021 Thomas Pelletier, Eric Anderton
+License: Apache-2.0
+
+Files: vendor/github.com/pierrec/lz4/*
+Copyright: Copyright (c) 2015, Pierre Curto
+License: BSD-3-Clause
+
+Files: vendor/github.com/pkg/errors/*
+Copyright: Copyright (c) 2015, Dave Cheney
+License: BSD-2-Clause
+
+Files: vendor/github.com/prometheus/client_golang/*
+Copyright: Copyright 2012-2015 The Prometheus Authors
+Copyright: Copyright 2013-2015 Blake Mizerany, Bjorn Rabenstein
+Copyright: Copyright 2010 The Go Authors
+Copyright: Copyright 2013 Matt T. Proud
+License: Apache-2.0
+
+Files: vendor/github.com/prometheus/client_model/*
+Copyright: Copyright 2012-2015 The Prometheus Authors
+License: Apache-2.0
+
+Files: vendor/github.com/prometheus/common/*
+Copyright: Copyright 2015 The Prometheus Authors
+License: Apache-2.0
+
+Files: vendor/github.com/prometheus/procfs/*
+Copyright: Copyright 2014 Prometheus Team
+License: Apache-2.0
+
+Files: vendor/github.com/PuerkitoBio/purell/*
+Copyright: Copyright (c) 2012, Martin Angers
+License: BSD-3-Clause
+
+Files: vendor/github.com/PuerkitoBio/urlesc/*
+Copyright: Copyright (c) 2012 The Go Authors
+License: BSD-3-Clause
+
+Files: vendor/github.com/russross/blackfriday/v2/*
+Copyright: Copyright (c) 2011 Russ Ross
+License: BSD-2-Clause
+
+Files: vendor/github.com/shurcooL/sanitized_anchor_name/*
+Copyright: Copyright (c) 2015 Dmitri Shuralyov
+License: MIT
+
+Files: vendor/github.com/sirupsen/logrus/*
+Copyright: Copyright (c) 2014 Simon Eskildsen
+License: MIT
+
+Files: vendor/github.com/spf13/afero/*
+Copyright: Copyright (c) 2015 Steve Francia 
+Copyright: Portions Copyright (c) 2015 The Hugo Authors
+Copyright: Portions Copyright 2016-present Bjorn Erik Pedersen
+License: Apache-2.0
+
+Files: vendor/github.com/spf13/cast/*
+Copyright: Copyright (c) 2014 Steve Francia
+License: MIT
+
+Files: vendor/github.com/spf13/cobra/*
+Copyright: Copyright (c) 2013 Steve Francia
+License: Apache-2.0
+
+Files: vendor/github.com/spf13/jwalterweatherman/*
+Copyright: Copyright (c) 2014 Steve Francia
+License: MIT
+
+Files: vendor/github.com/spf13/pflag/*
+Copyright: Copyright (c) 2012 Alex Ogier
+Copyright: Copyright (c) 2012 The Go Authors
+License: BSD-3-Clause
+
+Files: vendor/github.com/spf13/viper/*
+Copyright: Copyright (c) 2014 Steve Francia
+License: MIT
+
+Files: vendor/github.com/subosito/gotenv/*
+Copyright: Copyright (c) 2013 Alif Rachmawadi
+License: MIT
+
+Files: vendor/github.com/texttheater/golang-levenshtein/*
+Copyright: Copyright (c) 2013 Kilian Evang and contributors
+License: MIT
+
+Files: vendor/github.com/ulikunitz/xz/*
+Copyright: Copyright 2014-2021 Ulrich Kunitz
+License: BSD-3-Clause
+
+Files: vendor/github.com/xi2/xz/*
+Copyright: Lasse Collin
+License: LicenseRef-PUBLIC-DOMAIN-xi2-xy
+
+Files: vendor/go.uber.org/atomic/*
+Copyright: Copyright (c) 2020 Uber Technologies, Inc.
+License: MIT
+
+Files: vendor/go.uber.org/multierr/*
+Copyright: Copyright (c) 2019 Uber Technologies, Inc.
+License: MIT
+
+Files: vendor/go.uber.org/zap/*
+Copyright: Copyright 2018 The Kubernetes Authors
+License: MIT
+
+Files: vendor/golang.org/x/crypto/*
+Copyright: Copyright (c) 2009 The Go Authors
+License: BSD-3-Clause
+
+Files: vendor/golang.org/x/mod/*
+Copyright: Copyright (c) 2009 The Go Authors
+License: BSD-3-Clause
+
+Files: vendor/golang.org/x/net/*
+Copyright: Copyright (c) 2009 The Go Authors
+License: BSD-3-Clause
+
+Files: vendor/golang.org/x/oauth2/*
+Copyright: Copyright (c) 2009 The Go Authors
+License: BSD-3-Clause
+
+Files: vendor/golang.org/x/sys/*
+Copyright: Copyright (c) 2009 The Go Authors
+License: BSD-3-Clause
+
+Files: vendor/golang.org/x/term/*
+Copyright: Copyright (c) 2009 The Go Authors
+License: BSD-3-Clause
+
+Files: vendor/golang.org/x/text/*
+Copyright: Copyright (c) 2009 The Go Authors
+License: BSD-3-Clause
+
+Files: vendor/golang.org/x/time/*
+Copyright: Copyright (c) 2009 The Go Authors
+License: BSD-3-Clause
+
+Files: vendor/golang.org/x/tools/*
+Copyright: Copyright (c) 2009 The Go Authors
+License: BSD-3-Clause
+
+Files: vendor/golang.org/x/xerrors/*
+Copyright: Copyright 2018 The Go Authors
+License: BSD-3-Clause
+
+Files: vendor/gomodules.xyz/jsonpatch/v2/*
+Copyright: n/a
+License: Apache-2.0
+
+Files: vendor/google.golang.org/appengine/*
+Copyright: Copyright 2011 Google Inc.
+License: Apache-2.0
+
+Files: vendor/google.golang.org/protobuf/*
+Copyright: Copyright 2008 Google Inc.
+License: BSD-3-Clause
+
+Files: vendor/gopkg.in/inf.v0/*
+Copyright: Copyright (c) 2012 Peter Suranyi
+Copyright: Portions Copyright (c) 2009 The Go Authors
+License: BSD-3-Clause
+
+Files: vendor/gopkg.in/ini.v1/*
+Copyright: Copyright 2019 Unknwon
+License: Apache-2.0
+
+Files: vendor/gopkg.in/tomb.v1/*
+Copyright: Copyright (c) 2010-2011 - Gustavo Niemeyer
+License: BSD-3-Clause
+
+Files: vendor/gopkg.in/yaml.v2/*
+Copyright: Copyright 2011-2016 Canonical Ltd.
+License: Apache-2.0 and MIT
+
+Files: vendor/gopkg.in/yaml.v3/*
+Copyright: Copyright (c) 2011-2019 Canonical Ltd
+Copyright: Copyright (c) 2006-2010 Kirill Simonov
+License: MIT and Apache-2.0
+
+Files: vendor/istio.io/api/*
+Copyright: Copyright 2016-2020 Istio
+License: Apache-2.0
+
+Files: vendor/istio.io/client-go/*
+Copyright: Copyright 2016-2020 Istio
+License: Apache-2.0
+
+Files: vendor/istio.io/gogo-genproto/*
+Copyright: Copyright 2016-2020 Istio
+License: Apache-2.0
+
+Files: vendor/k8s.io/api/*
+Copyright: Copyright 2019 The Kubernetes Authors
+License: Apache-2.0
+
+Files: vendor/k8s.io/apiextensions-apiserver/*
+Copyright: Copyright 2017 The Kubernetes Authors
+License: Apache-2.0
+
+Files: vendor/k8s.io/apimachinery/*
+Copyright: Copyright 2014 The Kubernetes Authors
+License: Apache-2.0 and BSD-3-Clause
+
+Files: vendor/k8s.io/apiserver/*
+Copyright: Copyright 2014 The Kubernetes Authors
+License: Apache-2.0
+
+Files: vendor/k8s.io/autoscaler/*
+Copyright: Copyright 2019 The Kubernetes Authors
+License: Apache-2.0
+
+Files: vendor/k8s.io/client-go/*
+Copyright: Copyright 2015 The Kubernetes Authors
+License: Apache-2.0
+
+Files: vendor/k8s.io/code-generator/*
+Copyright: Copyright 2017 The Kubernetes Authors
+License: Apache-2.0 and BSD-3-Clause
+
+Files: vendor/k8s.io/component-base/*
+Copyright: Copyright 2018 The Kubernetes Authors
+License: Apache-2.0
+
+Files: vendor/k8s.io/gengo/*
+Copyright: Copyright 2014 The Kubernetes Authors
+License: Apache-2.0
+
+Files: vendor/k8s.io/helm/*
+Copyright: n/a
+License: Apache-2.0
+
+Files: vendor/k8s.io/klog/*
+Copyright: Copyright 2013 Google Inc.
+License: Apache-2.0
+
+Files: vendor/k8s.io/klog/v2/*
+Copyright: Copyright 2013 Google Inc.
+License: Apache-2.0
+
+Files: vendor/k8s.io/kube-aggregator/*
+Copyright: Copyright 2016 The Kubernetes Authors
+License: Apache-2.0
+
+Files: vendor/k8s.io/kube-openapi/*
+Copyright: Copyright 2015 go-swagger
+License: Apache-2.0
+
+Files: vendor/k8s.io/metrics/*
+Copyright: Copyright 2017 The Kubernetes Authors
+License: Apache-2.0
+
+Files: vendor/k8s.io/utils/*
+Copyright: Copyright 2017 The Kubernetes Authors
+License: Apache-2.0
+
+Files: vendor/sigs.k8s.io/controller-runtime/*
+Copyright: Copyright 2018 The Kubernetes Authors
+License: Apache-2.0
+
+Files: vendor/sigs.k8s.io/controller-tools/*
+Copyright: Copyright 2018 The Kubernetes Authors
+License: Apache-2.0
+
+Files: vendor/sigs.k8s.io/structured-merge-diff/v4/*
+Copyright: Copyright 2018 The Kubernetes Authors
+License: Apache-2.0
+
+Files: vendor/sigs.k8s.io/yaml/*
+Copyright: Copyright (c) 2014 Sam Ghods
+Copyright: Copyright (c) 2012 The Go Authors
+License: MIT and BSD-3-Clause

--- a/LICENSES/BSD-2-Clause.txt
+++ b/LICENSES/BSD-2-Clause.txt
@@ -1,0 +1,9 @@
+Copyright (c) <year> <owner> 
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSES/BSD-3-Clause.txt
+++ b/LICENSES/BSD-3-Clause.txt
@@ -1,0 +1,11 @@
+Copyright (c) <year> <owner>. 
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSES/ISC.txt
+++ b/LICENSES/ISC.txt
@@ -1,0 +1,8 @@
+ISC License:
+
+Copyright (c) 2004-2010 by Internet Systems Consortium, Inc. ("ISC")
+Copyright (c) 1995-2003 by Internet Software Consortium
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/LICENSES/LicenseRef-PUBLIC-DOMAIN-xi2-xy.txt
+++ b/LICENSES/LicenseRef-PUBLIC-DOMAIN-xi2-xy.txt
@@ -1,0 +1,18 @@
+Licensing of github.com/xi2/xz
+==============================
+
+    This Go package is a modified version of
+
+        XZ Embedded  <http://tukaani.org/xz/embedded.html>
+
+    The contents of the testdata directory are modified versions of
+    the test files from
+
+        XZ Utils  <http://tukaani.org/xz/>
+
+    All the files in this package have been written by Michael Cross,
+    Lasse Collin and/or Igor PavLov. All these files have been put
+    into the public domain. You can do whatever you want with these
+    files.
+
+    This software is provided "as is", without any warranty.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSES/MPL-2.0.txt
+++ b/LICENSES/MPL-2.0.txt
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/example/controller-registration.yaml
+++ b/example/controller-registration.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 ---
 apiVersion: core.gardener.cloud/v1beta1
 kind: ControllerDeployment

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 package metrics
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:
Achieve REUSE compliance for this repo

**Which issue(s) this PR fixes**:
The README claims that the project is REUSE compliant but "reuse lint" found missing license and copyright attributions

**Special notes for your reviewer**:

**Release note**:

```other developer
Make project REUSE compliant, see https://reuse.software/
```
