### PR TITLE
Add pod security policy

### DIFF
--- a/hack/api-reference/config.md
+++ b/hack/api-reference/config.md
@@ -216,6 +216,17 @@ EnsureConnectivity
 <p>EnsureConnectivity configures the removal of seed and/or shoot load balancers IPs from the filter list.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>pspDisabled</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>PSPDisabled is a flag to disable pod security policy.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="shoot-networking-filter.extensions.config.gardener.cloud/v1alpha1.EnsureConnectivity">EnsureConnectivity

--- a/pkg/apis/config/types.go
+++ b/pkg/apis/config/types.go
@@ -42,6 +42,9 @@ type EgressFilter struct {
 
 	// EnsureConnectivity configures the removal of seed and/or shoot load balancers IPs from the filter list.
 	EnsureConnectivity *EnsureConnectivity
+
+	// PSPDisabled is a flag to disable pod security policy.
+	PSPDisabled *bool
 }
 
 // FilterListProviderType

--- a/pkg/apis/config/v1alpha1/types.go
+++ b/pkg/apis/config/v1alpha1/types.go
@@ -48,6 +48,9 @@ type EgressFilter struct {
 	// EnsureConnectivity configures the removal of seed and/or shoot load balancers IPs from the filter list.
 	// +optional
 	EnsureConnectivity *EnsureConnectivity `json:"ensureConnectivity,omitempty"`
+
+	// PSPDisabled is a flag to disable pod security policy.
+	PSPDisabled *bool `json:"pspDisabled,omitempty"`
 }
 
 // FilterListProviderType

--- a/pkg/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.conversion.go
@@ -132,6 +132,7 @@ func autoConvert_v1alpha1_EgressFilter_To_config_EgressFilter(in *EgressFilter, 
 	out.StaticFilterList = *(*[]config.Filter)(unsafe.Pointer(&in.StaticFilterList))
 	out.DownloaderConfig = (*config.DownloaderConfig)(unsafe.Pointer(in.DownloaderConfig))
 	out.EnsureConnectivity = (*config.EnsureConnectivity)(unsafe.Pointer(in.EnsureConnectivity))
+	out.PSPDisabled = (*bool)(unsafe.Pointer(in.PSPDisabled))
 	return nil
 }
 
@@ -146,6 +147,7 @@ func autoConvert_config_EgressFilter_To_v1alpha1_EgressFilter(in *config.EgressF
 	out.StaticFilterList = *(*[]Filter)(unsafe.Pointer(&in.StaticFilterList))
 	out.DownloaderConfig = (*DownloaderConfig)(unsafe.Pointer(in.DownloaderConfig))
 	out.EnsureConnectivity = (*EnsureConnectivity)(unsafe.Pointer(in.EnsureConnectivity))
+	out.PSPDisabled = (*bool)(unsafe.Pointer(in.PSPDisabled))
 	return nil
 }
 

--- a/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -94,6 +94,11 @@ func (in *EgressFilter) DeepCopyInto(out *EgressFilter) {
 		*out = new(EnsureConnectivity)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.PSPDisabled != nil {
+		in, out := &in.PSPDisabled, &out.PSPDisabled
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/config/zz_generated.deepcopy.go
+++ b/pkg/apis/config/zz_generated.deepcopy.go
@@ -94,6 +94,11 @@ func (in *EgressFilter) DeepCopyInto(out *EgressFilter) {
 		*out = new(EnsureConnectivity)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.PSPDisabled != nil {
+		in, out := &in.PSPDisabled, &out.PSPDisabled
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -22,6 +22,8 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -60,12 +62,16 @@ type actuator struct {
 // Reconcile the Extension resource.
 func (a *actuator) Reconcile(ctx context.Context, ex *extensionsv1alpha1.Extension) error {
 	blackholingEnabled := true
+	pspEnabled := true
 	secretData := map[string][]byte{
 		constants.KeyIPV4List: []byte("[]"),
 		constants.KeyIPV6List: []byte("[]"),
 	}
 	if a.serviceConfig.EgressFilter != nil {
 		blackholingEnabled = a.serviceConfig.EgressFilter.BlackholingEnabled
+		if a.serviceConfig.EgressFilter.PSPDisabled != nil {
+			pspEnabled = !*a.serviceConfig.EgressFilter.PSPDisabled
+		}
 		var err error
 		secretData, err = a.readAndRestrictFilterListSecretData(ctx)
 		if err != nil {
@@ -73,7 +79,7 @@ func (a *actuator) Reconcile(ctx context.Context, ex *extensionsv1alpha1.Extensi
 		}
 	}
 
-	shootResources, err := getShootResources(blackholingEnabled, secretData)
+	shootResources, err := getShootResources(blackholingEnabled, pspEnabled, secretData)
 	if err != nil {
 		return err
 	}
@@ -212,7 +218,7 @@ func (a *actuator) setupFilterListProvider() error {
 	return a.provider.Setup()
 }
 
-func getShootResources(blackholingEnabled bool, secretData map[string][]byte) (map[string][]byte, error) {
+func getShootResources(blackholingEnabled, pspEnabled bool, secretData map[string][]byte) (map[string][]byte, error) {
 	shootRegistry := managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
 
 	if secretData == nil {
@@ -226,29 +232,40 @@ func getShootResources(blackholingEnabled bool, secretData map[string][]byte) (m
 
 	checksumEgressFilter := utils.ComputeSecretChecksum(secretData)
 
-	daemonset, err := buildDaemonset(checksumEgressFilter, blackholingEnabled)
+	var objects []client.Object
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.EgressFilterSecretName,
+			Namespace: constants.NamespaceKubeSystem,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: secretData,
+	}
+	objects = append(objects, secret)
+	serviceAccountName := ""
+	if pspEnabled {
+		serviceAccountName = constants.ApplicationName
+		pspObjects, err := buildPodSecurityPolicy(serviceAccountName)
+		if err != nil {
+			return nil, err
+		}
+		objects = append(objects, pspObjects...)
+	}
+
+	daemonset, err := buildDaemonset(checksumEgressFilter, blackholingEnabled, serviceAccountName)
 	if err != nil {
 		return nil, err
 	}
-	shootResources, err := shootRegistry.AddAllAndSerialize(
-		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      constants.EgressFilterSecretName,
-				Namespace: constants.NamespaceKubeSystem,
-			},
-			Type: corev1.SecretTypeOpaque,
-			Data: secretData,
-		},
-		daemonset,
-	)
+	objects = append(objects, daemonset)
 
+	shootResources, err := shootRegistry.AddAllAndSerialize(objects...)
 	if err != nil {
 		return nil, err
 	}
 	return shootResources, nil
 }
 
-func buildDaemonset(checksumEgressFilter string, blackholingEnabled bool) (client.Object, error) {
+func buildDaemonset(checksumEgressFilter string, blackholingEnabled bool, serviceAccountName string) (client.Object, error) {
 	var (
 		requestCPU, _          = resource.ParseQuantity("50m")
 		limitCPU, _            = resource.ParseQuantity("100m")
@@ -313,6 +330,7 @@ func buildDaemonset(checksumEgressFilter string, blackholingEnabled bool) (clien
 						},
 					},
 					AutomountServiceAccountToken: pointer.Bool(false),
+					ServiceAccountName:           serviceAccountName,
 					Containers: []corev1.Container{{
 						Name:            constants.ApplicationName,
 						Image:           image.String(),
@@ -355,4 +373,88 @@ func buildDaemonset(checksumEgressFilter string, blackholingEnabled bool) (clien
 			},
 		},
 	}, nil
+}
+
+func buildPodSecurityPolicy(serviceAccountName string) ([]client.Object, error) {
+	roleName := "gardener.cloud:psp:kube-system:" + constants.ApplicationName
+	resourceName := "gardener.kube-system." + constants.ApplicationName
+	clusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: roleName,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups:       []string{"policy"},
+				Verbs:           []string{"use"},
+				Resources:       []string{"podsecuritypolicies"},
+				ResourceNames:   []string{resourceName},
+				NonResourceURLs: nil,
+			},
+		},
+	}
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: roleName,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     roleName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      serviceAccountName,
+				Namespace: constants.NamespaceKubeSystem,
+			},
+		},
+	}
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceAccountName,
+			Namespace: constants.NamespaceKubeSystem,
+		},
+	}
+	t := true
+	psp := &policyv1beta1.PodSecurityPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: resourceName,
+		},
+		Spec: policyv1beta1.PodSecurityPolicySpec{
+			Privileged:               false,
+			DefaultAddCapabilities:   nil,
+			RequiredDropCapabilities: nil,
+			AllowedCapabilities:      []corev1.Capability{"NET_ADMIN"},
+			Volumes:                  []policyv1beta1.FSType{"secret"},
+			HostNetwork:              true,
+			HostPorts:                nil,
+			HostPID:                  false,
+			HostIPC:                  false,
+			SELinux: policyv1beta1.SELinuxStrategyOptions{
+				Rule: policyv1beta1.SELinuxStrategyRunAsAny,
+			},
+			RunAsUser: policyv1beta1.RunAsUserStrategyOptions{
+				Rule: policyv1beta1.RunAsUserStrategyRunAsAny,
+			},
+			RunAsGroup: nil,
+			SupplementalGroups: policyv1beta1.SupplementalGroupsStrategyOptions{
+				Rule: policyv1beta1.SupplementalGroupsStrategyRunAsAny,
+			},
+			FSGroup: policyv1beta1.FSGroupStrategyOptions{
+				Rule: policyv1beta1.FSGroupStrategyRunAsAny,
+			},
+			ReadOnlyRootFilesystem:          false,
+			DefaultAllowPrivilegeEscalation: nil,
+			AllowPrivilegeEscalation:        &t,
+			AllowedHostPaths:                nil,
+			AllowedFlexVolumes:              nil,
+			AllowedCSIDrivers:               nil,
+			AllowedUnsafeSysctls:            nil,
+			ForbiddenSysctls:                nil,
+			AllowedProcMountTypes:           nil,
+			RuntimeClass:                    nil,
+		},
+	}
+
+	return []client.Object{clusterRole, clusterRoleBinding, serviceAccount, psp}, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add pod security policy as egress-filter-applier daemon set needs `NET_ADMIN` capability.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Add pod security policy for egress-filter-applier daemon set 
```
