### PR TITLE
Change base image from alpine to distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ COPY . .
 RUN make install
 
 ############# gardener-extension-shoot-networking-filter
-FROM alpine:3.15.4 AS gardener-extension-shoot-networking-filter
+FROM  gcr.io/distroless/static-debian11:nonroot AS gardener-extension-shoot-networking-filter
+WORKDIR /
 
 COPY charts /charts
 COPY --from=builder /go/bin/gardener-extension-shoot-networking-filter /gardener-extension-shoot-networking-filter


### PR DESCRIPTION
/area open-source security
/kind enhancement

**What this PR does / why we need it**:
This PR changes the base image from `alpine` to [distroless](https://github.com/GoogleContainerTools/distroless). The processes will now use a non root user for their execution. This will reduce the attack surface of the images.

**Special notes for your reviewer**:
Part of [Container Hardening Guide v20 Compliance (Compliance with SCR3)](https://github.com/gardener/backlog/issues/7)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The extension now uses `distroless` instead of `alpine` as a base image.
```