### PR TITLE
Remove install-requirement and use tools.mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,6 @@ docker-images:
 # Rules for verification, formatting, linting, testing and cleaning #
 #####################################################################
 
-.PHONY: install-requirements
-install-requirements:
-	@$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/install-requirements.sh
-
 .PHONY: revendor
 revendor:
 	@GO111MODULE=on go mod tidy


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adapts the tool concept according to https://github.com/gardener/gardener/issues/6396 and removes the install-requirement script to install dependencies required for development on the fly and as needed.
See a detailed explanation/motivation in https://github.com/gardener/gardener/pull/4879.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6396

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
