### PR TITLE
Don't deploy `PSP`s when `PodSecurityPolicy` plugin is disabled 

### DIFF
--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -14,7 +14,10 @@ import (
 	"github.com/gardener/gardener-extension-shoot-networking-filter/pkg/apis/config"
 	"github.com/gardener/gardener-extension-shoot-networking-filter/pkg/constants"
 	"github.com/gardener/gardener-extension-shoot-networking-filter/pkg/imagevector"
+
+	"github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/extension"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
@@ -77,6 +80,15 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, ex *extensionsv
 		if err != nil {
 			return err
 		}
+	}
+
+	cluster, err := controller.GetCluster(ctx, a.client, ex.Namespace)
+	if err != nil {
+		return err
+	}
+
+	if gardencorev1beta1helper.IsPSPDisabled(cluster.Shoot) {
+		pspEnabled = false
 	}
 
 	shootResources, err := getShootResources(blackholingEnabled, pspEnabled, secretData)


### PR DESCRIPTION
**What this PR does / why we need it**:
`PodSecurityPolicy` is deprecated and will be disabled in kubernetes v1.25+.
End-users are provided an option to migrate their PSPs before upgrading and disable the `PodSecurityPolicy` admission plugin in the ShootSpec. 
In that case, we should stop deploying our PSPs as well.

- This PR stops deploying PSPs related to `shoot-networking-filter` if the plugin is disabled in the Shoot.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/5250

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Please make sure you're running gardener@v1.52 or above before upgrading to this version.
```

