### PR TITLE
Update builder image golang 1.18.3 -> 1.19.1

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,9 +1,6 @@
 run:
   concurrency: 4
   deadline: 10m
-  # some of the linters don't work correctly with 1.18, ref https://github.com/golangci/golangci-lint/issues/2649
-  # we are not using generics, so let's pin this to 1.17 until 1.18 is fully supported
-  go: "1.17"
 
 skip-files:
   - "zz_generated\\..*\\.go$"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ############# builder
-FROM golang:1.18.3 AS builder
+FROM golang:1.19.1 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-shoot-networking-filter
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ IGNORE_OPERATION_ANNOTATION := true
 
 
 TOOLS_DIR := $(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/tools
+GOLANGCI_LINT_VERSION := v1.49.0
 include $(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/tools.mk
 
 .PHONY: start

--- a/pkg/cmd/options.go
+++ b/pkg/cmd/options.go
@@ -7,7 +7,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 
 	apisconfig "github.com/gardener/gardener-extension-shoot-networking-filter/pkg/apis/config"
@@ -57,7 +57,7 @@ func (o *PolicyFilterOptions) Complete() error {
 	if o.ConfigLocation == "" {
 		return errors.New("config location is not set")
 	}
-	data, err := ioutil.ReadFile(o.ConfigLocation)
+	data, err := os.ReadFile(o.ConfigLocation)
 	if err != nil {
 		return err
 	}
@@ -72,17 +72,17 @@ func (o *PolicyFilterOptions) Complete() error {
 	if config.EgressFilter != nil && config.EgressFilter.DownloaderConfig != nil && o.OAuth2ConfigDir != "" {
 		secretData := &apisconfig.OAuth2Secret{}
 		filename := path.Join(o.OAuth2ConfigDir, constants.KeyClientID)
-		clientID, err := ioutil.ReadFile(filename)
+		clientID, err := os.ReadFile(filename)
 		if err != nil {
 			return fmt.Errorf("cannot read clientID from %s: %w", filename, err)
 		}
 		secretData.ClientID = string(clientID)
-		clientSecret, err := ioutil.ReadFile(path.Join(o.OAuth2ConfigDir, constants.KeyClientSecret))
+		clientSecret, err := os.ReadFile(path.Join(o.OAuth2ConfigDir, constants.KeyClientSecret))
 		if err == nil {
 			secretData.ClientSecret = string(clientSecret)
 		}
-		secretData.ClientCert, _ = ioutil.ReadFile(path.Join(o.OAuth2ConfigDir, constants.KeyClientCert))
-		secretData.ClientCertKey, _ = ioutil.ReadFile(path.Join(o.OAuth2ConfigDir, constants.KeyClientCertKey))
+		secretData.ClientCert, _ = os.ReadFile(path.Join(o.OAuth2ConfigDir, constants.KeyClientCert))
+		secretData.ClientCertKey, _ = os.ReadFile(path.Join(o.OAuth2ConfigDir, constants.KeyClientCertKey))
 		oauth2Secret = secretData
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Update builder image golang 1.18.3 -> 1.19.1. 

The golangci_lint version was updated and minor lint warnings have been fixed, too.


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update builder image golang `1.18.3` -> `1.19.1`
```
