### PR TITLE
Ensure `ServiceAccount` token gets invalidated

### DIFF
--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -443,6 +443,7 @@ func buildPodSecurityPolicy(serviceAccountName string) ([]client.Object, error) 
 			Name:      serviceAccountName,
 			Namespace: constants.NamespaceKubeSystem,
 		},
+		AutomountServiceAccountToken: pointer.Bool(false),
 	}
 	t := true
 	psp := &policyv1beta1.PodSecurityPolicy{


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensure `ServiceAccount` token gets invalidated

**Special notes for your reviewer**:
Ref https://github.com/gardener/gardener/blob/master/docs/concepts/resource-manager.md#tokeninvalidator

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The static (and unused) `ServiceAccount` token for the `egress-filter-applier` is now invalidated.
```
