### PR TITLE
Drop support for kubernetes < 1.20 for shoot networking filter extension

### DIFF
--- a/example/10-fake-shoot-controlplane.yaml
+++ b/example/10-fake-shoot-controlplane.yaml
@@ -88,6 +88,24 @@ data:
   kubeconfig: <kubeconfig-base64-encoded>
 ---
 apiVersion: v1
+kind: Secret
+metadata:
+  name: service-account-key
+  namespace: shoot--foo--bar
+type: Opaque
+data:
+  id_rsa: <rsa-key-base64-encoded>
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: service-account-key-bundle
+  namespace: shoot--foo--bar
+type: Opaque
+data:
+  bundle.key: <private-key-base64-encoded>
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: kube-apiserver
@@ -133,9 +151,8 @@ spec:
     spec:
       containers:
       - command:
-        - /hyperkube
-        - kube-apiserver
-        - --enable-admission-plugins=Priority,NamespaceLifecycle,LimitRanger,PodSecurityPolicy,ServiceAccount,NodeRestriction,DefaultStorageClass,DefaultTolerationSeconds,ResourceQuota,StorageObjectInUseProtection,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
+        - /usr/local/bin/kube-apiserver
+        - --enable-admission-plugins=Priority,NamespaceLifecycle,LimitRanger,ServiceAccount,NodeRestriction,DefaultStorageClass,DefaultTolerationSeconds,ResourceQuota,StorageObjectInUseProtection,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
         - --disable-admission-plugins=PersistentVolumeLabel
         - --allow-privileged=true
         - --anonymous-auth=false
@@ -147,14 +164,16 @@ spec:
         - --endpoint-reconciler-type=none
         - --etcd-servers=http://etcd:2379
         - --kubelet-preferred-address-types=InternalIP,Hostname,ExternalIP
-        - --insecure-port=0
         - --profiling=false
         - --secure-port=443
         - --service-cluster-ip-range=100.64.0.0/13
         - --tls-cert-file=/srv/kubernetes/apiserver/kube-apiserver.crt
         - --tls-private-key-file=/srv/kubernetes/apiserver/kube-apiserver.key
+        - --service-account-issuer=https://api.shoot-foo-bar.com
+        - --service-account-signing-key-file=/srv/kubernetes/service-account-key/id_rsa
+        - --service-account-key-file=/srv/kubernetes/service-account-key-bundle/bundle.key
         - --v=2
-        image: registry.k8s.io/hyperkube:v1.15.1
+        image: registry.k8s.io/kube-apiserver:v1.24.6
         imagePullPolicy: IfNotPresent
         name: kube-apiserver
         ports:
@@ -171,6 +190,10 @@ spec:
           name: ca
         - mountPath: /srv/kubernetes/apiserver
           name: kube-apiserver
+        - mountPath: /srv/kubernetes/service-account-key
+          name: service-account-key
+        - mountPath: /srv/kubernetes/service-account-key-bundle
+          name: service-account-key-bundle
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -188,3 +211,11 @@ spec:
         secret:
           defaultMode: 420
           secretName: kube-apiserver
+      - name: service-account-key
+        secret:
+          defaultMode: 420
+          secretName: service-account-key
+      - name: service-account-key-bundle
+        secret:
+          defaultMode: 420
+          secretName: service-account-key-bundle

--- a/example/30-cluster.yaml
+++ b/example/30-cluster.yaml
@@ -24,7 +24,7 @@ spec:
       dns:
         domain: foo.bar.example.com
       kubernetes:
-        version: 1.18.2
+        version: 1.24.8
       resources:
         - name: issuer-custom-eab-hmackey
           resourceRef:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/gardener/gardener-extension-shoot-networking-filter
 go 1.19
 
 require (
-	github.com/Masterminds/semver v1.5.0
 	github.com/ahmetb/gen-crd-api-reference-docs v0.2.0
 	github.com/gardener/gardener v1.59.0
 	github.com/go-logr/logr v1.2.3
@@ -26,6 +25,7 @@ require (
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
+	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect

--- a/hack/api-reference/config.json
+++ b/hack/api-reference/config.json
@@ -9,7 +9,7 @@
     "externalPackages": [
         {
             "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
-            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
         },
         {
             "typeMatchPrefix": "github.com/gardener/gardener/extensions/pkg/apis/config",

--- a/hack/api-reference/config.md
+++ b/hack/api-reference/config.md
@@ -117,7 +117,7 @@ If specified, the OAuth2Secret must be provided, too.</p>
 <td>
 <code>refreshPeriod</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#duration-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#duration-v1-meta">
 Kubernetes meta/v1.Duration
 </a>
 </em>

--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gardener/gardener-extension-shoot-networking-filter/pkg/constants"
 	"github.com/gardener/gardener-extension-shoot-networking-filter/pkg/imagevector"
 
-	"github.com/Masterminds/semver"
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/extension"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
@@ -23,7 +22,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
 	managedresources "github.com/gardener/gardener/pkg/utils/managedresources"
-	versionutils "github.com/gardener/gardener/pkg/utils/version"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -93,12 +91,7 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, ex *extensionsv
 		pspEnabled = false
 	}
 
-	k8sVersion, err := semver.NewVersion(cluster.Shoot.Spec.Kubernetes.Version)
-	if err != nil {
-		return err
-	}
-
-	shootResources, err := getShootResources(blackholingEnabled, pspEnabled, secretData, k8sVersion)
+	shootResources, err := getShootResources(blackholingEnabled, pspEnabled, secretData)
 	if err != nil {
 		return err
 	}
@@ -237,7 +230,7 @@ func (a *actuator) setupFilterListProvider() error {
 	return a.provider.Setup()
 }
 
-func getShootResources(blackholingEnabled, pspEnabled bool, secretData map[string][]byte, k8sVersion *semver.Version) (map[string][]byte, error) {
+func getShootResources(blackholingEnabled, pspEnabled bool, secretData map[string][]byte) (map[string][]byte, error) {
 	shootRegistry := managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
 
 	if secretData == nil {
@@ -271,7 +264,7 @@ func getShootResources(blackholingEnabled, pspEnabled bool, secretData map[strin
 		objects = append(objects, pspObjects...)
 	}
 
-	daemonset, err := buildDaemonset(checksumEgressFilter, blackholingEnabled, serviceAccountName, k8sVersion)
+	daemonset, err := buildDaemonset(checksumEgressFilter, blackholingEnabled, serviceAccountName)
 	if err != nil {
 		return nil, err
 	}
@@ -284,7 +277,7 @@ func getShootResources(blackholingEnabled, pspEnabled bool, secretData map[strin
 	return shootResources, nil
 }
 
-func buildDaemonset(checksumEgressFilter string, blackholingEnabled bool, serviceAccountName string, k8sVersion *semver.Version) (client.Object, error) {
+func buildDaemonset(checksumEgressFilter string, blackholingEnabled bool, serviceAccountName string) (client.Object, error) {
 	var (
 		requestCPU, _          = resource.ParseQuantity("50m")
 		requestMemory, _       = resource.ParseQuantity("64Mi")
@@ -314,7 +307,7 @@ func buildDaemonset(checksumEgressFilter string, blackholingEnabled bool, servic
 			Labels:    labels,
 		},
 		Spec: appsv1.DaemonSetSpec{
-			RevisionHistoryLimit: pointer.Int32Ptr(5),
+			RevisionHistoryLimit: pointer.Int32(5),
 			Selector:             &metav1.LabelSelector{MatchLabels: labels},
 			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 				Type: appsv1.RollingUpdateDaemonSetStrategyType,
@@ -391,14 +384,12 @@ func buildDaemonset(checksumEgressFilter string, blackholingEnabled bool, servic
 		},
 	}
 
-	if versionutils.ConstraintK8sGreaterEqual119.Check(k8sVersion) {
-		if ds.Spec.Template.Spec.SecurityContext == nil {
-			ds.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{}
-		}
+	if ds.Spec.Template.Spec.SecurityContext == nil {
+		ds.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{}
+	}
 
-		ds.Spec.Template.Spec.SecurityContext.SeccompProfile = &corev1.SeccompProfile{
-			Type: corev1.SeccompProfileTypeRuntimeDefault,
-		}
+	ds.Spec.Template.Spec.SecurityContext.SeccompProfile = &corev1.SeccompProfile{
+		Type: corev1.SeccompProfileTypeRuntimeDefault,
 	}
 
 	return ds, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Drop support for kubernetes < 1.20 for shoot networking filter extension

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6911

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
shoot-networking-filter no longer supports Shoots with Кubernetes version < 1.20.
```
