### PR TITLE
Update builder image to golang:1.19.5

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -19,7 +19,8 @@ gardener-extension-shoot-networking-filter:
   jobs:
     head-update:
       traits:
-        component_descriptor: ~
+        component_descriptor:
+          retention_policy: 'clean-snapshots'
         draft_release: ~
         options:
           public_build_logs: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ############# builder
-FROM golang:1.19.4 AS builder
+FROM golang:1.19.5 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-shoot-networking-filter
 COPY . .


### PR DESCRIPTION
**What this PR does / why we need it**:
Update builder image to golang:1.19.5

**Special notes for your reviewer**:
Also enabled clean-snapshot.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update builder image from `golang:1.19.4` to `golang:1.19.5`
```
