### PR TITLE
Make `blackholing` configureable per shoot.

### DIFF
--- a/cmd/gardener-extension-shoot-networking-filter/app/app.go
+++ b/cmd/gardener-extension-shoot-networking-filter/app/app.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	filterinstall "github.com/gardener/gardener-extension-shoot-networking-filter/pkg/apis/config/install"
 	"github.com/gardener/gardener-extension-shoot-networking-filter/pkg/controller/healthcheck"
 	"github.com/gardener/gardener-extension-shoot-networking-filter/pkg/controller/lifecycle"
 )
@@ -72,6 +73,10 @@ func (o *Options) run(ctx context.Context) error {
 	}
 
 	if err := extensionscontroller.AddToScheme(mgr.GetScheme()); err != nil {
+		return fmt.Errorf("could not update manager scheme: %s", err)
+	}
+
+	if err := filterinstall.AddToScheme(mgr.GetScheme()); err != nil {
 		return fmt.Errorf("could not update manager scheme: %s", err)
 	}
 

--- a/docs/usage/shoot-networking-filter.md
+++ b/docs/usage/shoot-networking-filter.md
@@ -47,6 +47,11 @@ spec:
         blackholingEnabled: true
 ...
 ```
+Ingress traffic can only be blocked, if the source IP address is preserved.
+In order to preserve the source IP address of a client when accessing a Service via a load balancer,
+you can use the "externalTrafficPolicy" setting in the Service specification. It may also require additional configuration of the load balancer
+depending on the infrastructure provider. Please check the documentation and capabilities of the infrastructure provider's load balancer to ensure that source IP preservation is supported.
+
 Please note that if you disable `blackholing` in an existing shoot, the associated blackhole routes will not be removed automatically. 
 To remove these routes, you can either replace the affected nodes or delete the routes manually.
 

--- a/docs/usage/shoot-networking-filter.md
+++ b/docs/usage/shoot-networking-filter.md
@@ -47,10 +47,10 @@ spec:
         blackholingEnabled: true
 ...
 ```
-Ingress traffic can only be blocked, if the source IP address is preserved.
-In order to preserve the source IP address of a client when accessing a Service via a load balancer,
-you can use the "externalTrafficPolicy" setting in the Service specification. It may also require additional configuration of the load balancer
-depending on the infrastructure provider. Please check the documentation and capabilities of the infrastructure provider's load balancer to ensure that source IP preservation is supported.
+Ingress traffic can only be blocked by blackhole routing, if the source IP address is preserved. On Azure, GCP and AliCloud this works by default.
+The default on AWS is a classic load balancer that replaces the source IP by it's own IP address. Here, a network load balancer has to be
+configured adding the annotation `service.beta.kubernetes.io/aws-load-balancer-type: "nlb"` to the service.
+On OpenStack, load balancers don't preserve the source address.
 
 Please note that if you disable `blackholing` in an existing shoot, the associated blackhole routes will not be removed automatically. 
 To remove these routes, you can either replace the affected nodes or delete the routes manually.

--- a/docs/usage/shoot-networking-filter.md
+++ b/docs/usage/shoot-networking-filter.md
@@ -31,7 +31,7 @@ spec:
 ...
 ```
 
-### Ingress Filtering
+## Ingress Filtering
 
 By default, the networking filter only filters egress traffic. However, if you enable blackholing, incoming traffic will also be blocked.
 You can enable blackholing on a per-shoot basis.
@@ -55,7 +55,7 @@ On OpenStack, load balancers don't preserve the source address.
 Please note that if you disable `blackholing` in an existing shoot, the associated blackhole routes will not be removed automatically. 
 To remove these routes, you can either replace the affected nodes or delete the routes manually.
 
-### Custom IP 
+## Custom IP 
 
 It is possible to add custom IP addresses to the network filter. This can be useful for testing purposes.
 

--- a/docs/usage/shoot-networking-filter.md
+++ b/docs/usage/shoot-networking-filter.md
@@ -31,3 +31,44 @@ spec:
 ...
 ```
 
+### Ingress Filtering
+
+By default, the networking filter only filters egress traffic. However, if you enable blackholing, incoming traffic will also be blocked.
+You can enable blackholing on a per-shoot basis.
+
+```yaml
+apiVersion: core.gardener.cloud/v1beta1
+kind: Shoot
+...
+spec:
+  extensions:
+    - type: shoot-networking-filter
+      egressFilter:
+        blackholingEnabled: true
+...
+```
+Please note that if you disable `blackholing` in an existing shoot, the associated blackhole routes will not be removed automatically. 
+To remove these routes, you can either replace the affected nodes or delete the routes manually.
+
+### Custom IP 
+
+It is possible to add custom IP addresses to the network filter. This can be useful for testing purposes.
+
+```yaml
+apiVersion: core.gardener.cloud/v1beta1
+kind: Shoot
+...
+spec:
+  extensions:
+    - type: shoot-networking-filter
+      egressFilter:
+        staticFilterList:
+          - network: 1.2.3.4/31
+            policy: BLOCK_ACCESS
+          - network: 5.6.7.8/32
+            policy: BLOCK_ACCESS
+          - network: ::2/128
+            policy: BLOCK_ACCESS
+...
+```
+

--- a/pkg/apis/config/install/install.go
+++ b/pkg/apis/config/install/install.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package install
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	"github.com/gardener/gardener-extension-shoot-networking-filter/pkg/apis/config"
+	"github.com/gardener/gardener-extension-shoot-networking-filter/pkg/apis/config/v1alpha1"
+)
+
+var (
+	schemeBuilder = runtime.NewSchemeBuilder(
+		v1alpha1.AddToScheme,
+		config.AddToScheme,
+		setVersionPriority,
+	)
+
+	// AddToScheme adds all APIs to the scheme.
+	AddToScheme = schemeBuilder.AddToScheme
+)
+
+func setVersionPriority(scheme *runtime.Scheme) error {
+	return scheme.SetVersionPriority(v1alpha1.SchemeGroupVersion)
+}
+
+// Install installs all APIs in the scheme.
+func Install(scheme *runtime.Scheme) {
+	utilruntime.Must(AddToScheme(scheme))
+}

--- a/pkg/apis/config/install/install.go
+++ b/pkg/apis/config/install/install.go
@@ -1,16 +1,6 @@
-// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package install
 

--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -58,7 +58,6 @@ type actuator struct {
 	config        *rest.Config
 	decoder       runtime.Decoder
 	serviceConfig config.Configuration
-	shootConfig   *v1alpha1.Configuration
 	oauth2secret  *config.OAuth2Secret
 	provider      filterListProvider
 	logger        logr.Logger
@@ -75,15 +74,15 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, ex *extensionsv
 		constants.KeyIPV6List: []byte("[]"),
 	}
 
-	a.shootConfig = &v1alpha1.Configuration{}
+	shootConfig := &v1alpha1.Configuration{}
 	if ex.Spec.ProviderConfig != nil {
-		if _, _, err := a.decoder.Decode(ex.Spec.ProviderConfig.Raw, nil, a.shootConfig); err != nil {
+		if _, _, err := a.decoder.Decode(ex.Spec.ProviderConfig.Raw, nil, shootConfig); err != nil {
 			return fmt.Errorf("failed to decode provider config: %w", err)
 		}
 	}
 
 	internalShootConfig := &config.Configuration{}
-	if err := a.scheme.Convert(a.shootConfig, internalShootConfig, nil); err != nil {
+	if err := a.scheme.Convert(shootConfig, internalShootConfig, nil); err != nil {
 		return fmt.Errorf("failed to convert shoot config: %w", err)
 	}
 

--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -101,7 +101,10 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, ex *extensionsv
 		staticProvider, ok := a.provider.(*staticFilterListProvider)
 		if ok {
 			staticProvider.filterList = a.serviceConfig.EgressFilter.StaticFilterList
-			a.provider.Setup()
+			err := a.provider.Setup()
+			if err != nil {
+				return err
+			}
 		}
 
 		var err error

--- a/pkg/controller/lifecycle/filterlistprovider.go
+++ b/pkg/controller/lifecycle/filterlistprovider.go
@@ -104,7 +104,12 @@ func newStaticFilterListProvider(ctx context.Context, client client.Client, logg
 }
 
 func (p *staticFilterListProvider) Setup() error {
-	return p.createOrUpdateFilterListSecret(p.ctx, p.filterList)
+	err := p.createOrUpdateFilterListSecret(p.ctx, p.filterList)
+	if err != nil {
+		p.logger.Info("secret update failed", "error", err)
+		return err
+	}
+	return nil
 }
 
 type downloaderFilterListProvider struct {


### PR DESCRIPTION

**What this PR does / why we need it**:
With blackhole routing ingress and egress traffic for configured IPs is blocked.
It can be enabled on per-shoot basis.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
With blackhole routing ingress and egress traffic for configured IPs is blocked.
It can be enabled on per-shoot basis.
```
