### PR TITLE
Fixed broken links - 2023.06

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ metadata:
 spec:
 ```
 
-When an extension resource is reconciled, the extension controller will create a daemonset `egress-filter-applier` on the shoot containing either
-a [blackholer](https://github.com/gardener/egress-filter-refresher/tree/master/blackholer) or [firewaller](https://github.com/gardener/egress-filter-refresher/tree/master/firewaller) container.
+When an extension resource is reconciled, the extension controller will create a daemonset `egress-filter-applier` on the shoot containing a [Dockerfile](https://github.com/gardener/egress-filter-refresher/blob/master/Dockerfile) container.
 
 
 Please note, this extension controller relies on the [Gardener-Resource-Manager](https://github.com/gardener/gardener/blob/master/docs/concepts/resource-manager.md) to deploy k8s resources to seed and shoot clusters.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes broken links in the documentation. The links were broken due to the [removal of the files being pointed to](https://github.com/gardener/egress-filter-refresher/commit/bc7d2ef8558f9c7658a5ba6eab837540ec7adf02#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557), replacing them with a single Dockerfile.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
