### PR TITLE
Mount xtables.lock file.

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -44,4 +44,8 @@ const (
 	KeyClientCert = "client.crt.pem"
 	// KeyClientCertKey is the key in the OAuth2 secret for the optional private key of the client certificate.
 	KeyClientCertKey = "client.key.pem"
+	// XtablesLockName is the name of volume and volumemount of the xtables lock file.
+	XtablesLockName = "xtables-lock"
+	// XtablesLockPath is the path of the xtables lock file.
+	XtablesLockPath = "/run/xtables.lock"
 )

--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -311,11 +311,12 @@ func getShootResources(blackholingEnabled, pspEnabled bool, sleepDuration string
 
 func buildDaemonset(checksumEgressFilter string, blackholingEnabled bool, sleepDuration string, serviceAccountName string) (client.Object, error) {
 	var (
-		requestCPU, _          = resource.ParseQuantity("50m")
-		requestMemory, _       = resource.ParseQuantity("64Mi")
-		limitMemory, _         = resource.ParseQuantity("256Mi")
-		defaultMode      int32 = 0400
-		zero             int64 = 0
+		requestCPU, _                        = resource.ParseQuantity("50m")
+		requestMemory, _                     = resource.ParseQuantity("64Mi")
+		limitMemory, _                       = resource.ParseQuantity("256Mi")
+		defaultMode      int32               = 0400
+		zero             int64               = 0
+		hostPathType     corev1.HostPathType = corev1.HostPathFileOrCreate
 	)
 
 	labels := map[string]string{
@@ -403,6 +404,11 @@ func buildDaemonset(checksumEgressFilter string, blackholingEnabled bool, sleepD
 								ReadOnly:  true,
 								MountPath: fmt.Sprintf("/%s", constants.FilterListPath),
 							},
+							{
+								Name:      constants.XtablesLockName,
+								ReadOnly:  false,
+								MountPath: constants.XtablesLockPath,
+							},
 						},
 					}},
 					Volumes: []corev1.Volume{
@@ -412,6 +418,15 @@ func buildDaemonset(checksumEgressFilter string, blackholingEnabled bool, sleepD
 								Secret: &corev1.SecretVolumeSource{
 									SecretName:  constants.EgressFilterSecretName,
 									DefaultMode: &defaultMode,
+								},
+							},
+						},
+						{
+							Name: constants.XtablesLockName,
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: constants.XtablesLockPath,
+									Type: &hostPathType,
 								},
 							},
 						},


### PR DESCRIPTION
**What this PR does / why we need it**:
Mount `/run/xtables.lock` to prevent concurrent modifications of iptables rules.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Mount `/run/xtables.lock` to prevent concurrent modifications of iptables rules.
```
