### PR TITLE
add hostPath in PSP - DaemonSet "kube-system/egress-filter-applier" is unhealthy

### DIFF
--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -502,7 +502,7 @@ func buildPodSecurityPolicy(serviceAccountName string) ([]client.Object, error) 
 			DefaultAddCapabilities:   nil,
 			RequiredDropCapabilities: nil,
 			AllowedCapabilities:      []corev1.Capability{"NET_ADMIN"},
-			Volumes:                  []policyv1beta1.FSType{"secret"},
+			Volumes:                  []policyv1beta1.FSType{"secret", "hostPath"},
 			HostNetwork:              true,
 			HostPorts:                nil,
 			HostPID:                  false,


### PR DESCRIPTION
**What this PR does / why we need it**:
current `egress-filter-applier` pod creations fail with:
```
Warning  FailedCreate  43m (x29 over 11h)    daemonset-controller  Error creating: pods "egress-filter-applier-" is forbidden: PodSecurityPolicy: unable to admit pod: [spec.volumes[1]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.securityContext.hostNetwork: Invalid value: true: Host network is not allowed to be used spec.volumes[1]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.containers[0].securityContext.capabilities.add: Invalid value: "NET_ADMIN": capability may not be added]
```


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
fix egress-filter-applier pod unable to be created due to `hostPath` missing in PSP. 
```
