### PR TITLE
Reduce `egress-filter-applier` resource requests

### DIFF
--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -291,8 +291,8 @@ func getShootResources(blackholingEnabled bool, sleepDuration, namespace string,
 
 func buildDaemonset(checksumEgressFilter string, blackholingEnabled bool, sleepDuration, namespace string) (client.Object, error) {
 	var (
-		requestCPU, _                        = resource.ParseQuantity("50m")
-		requestMemory, _                     = resource.ParseQuantity("64Mi")
+		requestCPU, _                        = resource.ParseQuantity("5m")
+		requestMemory, _                     = resource.ParseQuantity("20Mi")
 		limitMemory, _                       = resource.ParseQuantity("256Mi")
 		defaultMode      int32               = 0400
 		zero             int64               = 0


### PR DESCRIPTION
/kind enhancement

**What this PR does / why we need it**:
This PR reduces the  `resources.requests.cpu` and `resources.requests.memory` of the `egress-filter-applier` container to `5m` and `20Mi`, respectively. This optimisation is based on the 95th percentile across all  containers of that component found in our landscapes. 

Previously the utilisation was at 0% (for CPU) and 21% (for memory).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `resources.requests.cpu` and `resources.requests.memory` of the `egress-filter-applier` container have been reduced to `5m` and `20Mi`, respectively.
```
