### PR TITLE
Publish Helm charts as OCI artifacts

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -3,6 +3,27 @@
 # SPDX-License-Identifier: Apache-2.0
 
 gardener-extension-shoot-networking-filter:
+  templates:
+    helmcharts:
+    - &shoot-networking-filter
+      name: shoot-networking-filter
+      dir: charts/gardener-extension-shoot-networking-filter
+      registry: europe-docker.pkg.dev/gardener-project/snapshots/charts/gardener/extensions
+      mappings:
+      - ref: ocm-resource:gardener-extension-shoot-networking-filter.repository
+        attribute: image.repository
+      - ref: ocm-resource:gardener-extension-shoot-networking-filter.tag
+        attribute: image.tag
+    - &runtime-networking-filter
+      name: runtime-networking-filter
+      dir: charts/gardener-runtime-networking-filter
+      registry: europe-docker.pkg.dev/gardener-project/snapshots/charts/gardener/extensions
+      mappings:
+      - ref: ocm-resource:gardener-runtime-networking-filter.repository
+        attribute: global.image.repository
+      - ref: ocm-resource:gardener-runtime-networking-filter.tag
+        attribute: global.image.tag
+
   base_definition:
     traits:
       component_descriptor:
@@ -55,6 +76,10 @@ gardener-extension-shoot-networking-filter:
         draft_release: ~
         options:
           public_build_logs: true
+        publish:
+          helmcharts:
+          - *shoot-networking-filter
+          - *runtime-networking-filter
     pull-request:
       traits:
         pull-request: ~
@@ -63,6 +88,10 @@ gardener-extension-shoot-networking-filter:
             - repository: europe-docker.pkg.dev/gardener-project/releases
         options:
           public_build_logs: true
+        publish:
+          helmcharts:
+          - *shoot-networking-filter
+          - *runtime-networking-filter
     release:
       traits:
         version:
@@ -93,4 +122,8 @@ gardener-extension-shoot-networking-filter:
               resource_labels:
                 - name: imagevector.gardener.cloud/repository
                   value: europe-docker.pkg.dev/gardener-project/releases/gardener/extensions/runtime-networking-filter
-
+          helmcharts:
+          - <<: *shoot-networking-filter
+            registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions
+          - <<: *runtime-networking-filter
+            registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions


### PR DESCRIPTION
/area delivery
/kind enhancement

**What this PR does / why we need it**:
We should start publishing Helm charts as OCI artifacts that we can deploy them as `Extension` in the future (see https://github.com/gardener/gardener/issues/9635).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Helm charts of extension and admission controller are published as OCI artifacts now.
```
