### PR TITLE
Introduce `gosec` for Static Application Security Testing (SAST)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ testbin
 dive.log
 /tmp
 /local
+
+# gosec
+gosec-report.sarif

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ tidy:
 	@go mod tidy
 	@mkdir -p $(REPO_ROOT)/.ci/hack && cp $(GARDENER_HACK_DIR)/.ci/* $(GARDENER_HACK_DIR)/generate-controller-registration.sh $(REPO_ROOT)/.ci/hack/ && chmod +xw $(REPO_ROOT)/.ci/hack/*
 	@cp $(GARDENER_HACK_DIR)/cherry-pick-pull.sh $(HACK_DIR)/cherry-pick-pull.sh && chmod +xw $(HACK_DIR)/cherry-pick-pull.sh
+	@cp $(GARDENER_HACK_DIR)/sast.sh $(HACK_DIR)/sast.sh && chmod +xw $(HACK_DIR)/sast.sh
 
 .PHONY: clean
 clean:
@@ -90,6 +91,20 @@ generate: $(CONTROLLER_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(HELM) $(YQ) $(VGOPAT
 format: $(GOIMPORTS) $(GOIMPORTSREVISER)
 	@bash $(GARDENER_HACK_DIR)/format.sh ./cmd ./pkg ./test
 
+# TODO(scheererj): Remove once https://github.com/gardener/gardener/pull/10642 is available as release.
+TOOLS_PKG_PATH := $(shell go list -tags tools -f '{{ .Dir }}' github.com/gardener/gardener/hack/tools 2>/dev/null)
+.PHONY: adjust-install-gosec.sh
+adjust-install-gosec.sh:
+	@chmod +xw $(TOOLS_PKG_PATH)/install-gosec.sh
+
+.PHONY: sast
+sast: adjust-install-gosec.sh $(GOSEC)
+	@./hack/sast.sh
+
+.PHONY: sast-report
+sast-report: adjust-install-gosec.sh $(GOSEC)
+	@./hack/sast.sh --gosec-report true
+
 .PHONY: test
 test:
 	@SKIP_FETCH_TOOLS=1 bash $(GARDENER_HACK_DIR)/test.sh ./cmd/... ./pkg/...
@@ -103,10 +118,10 @@ test-clean:
 	@bash $(GARDENER_HACK_DIR)/test-cover-clean.sh
 
 .PHONY: verify
-verify: check format test
+verify: check format test sast
 
 .PHONY: verify-extended
-verify-extended: check-generate check format test test-cov test-clean
+verify-extended: check-generate check format test test-cov test-clean sast-report
 
 .PHONY: test-e2e-local
 test-e2e-local: $(KIND) $(YQ) $(GINKGO)

--- a/hack/sast.sh
+++ b/hack/sast.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+root_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
+
+gosec_report="false"
+gosec_report_parse_flags=""
+
+parse_flags() {
+  while test $# -gt 1; do
+    case "$1" in
+      --gosec-report)
+        shift; gosec_report="$1"
+        ;;
+      *)
+        echo "Unknown argument: $1"
+        exit 1
+        ;;
+    esac
+    shift
+  done
+}
+
+parse_flags "$@"
+
+echo "> Running gosec"
+gosec --version
+if [[ "$gosec_report" != "false" ]]; then
+  echo "Exporting report to $root_dir/gosec-report.sarif"
+  gosec_report_parse_flags="-track-suppressions -fmt=sarif -out=gosec-report.sarif -stdout"
+fi
+
+# Gardener uses code-generators https://github.com/kubernetes/code-generator and https://github.com/protocolbuffers/protobuf
+# which create lots of G103 (CWE-242: Use of unsafe calls should be audited) & G104 (CWE-703: Errors unhandled) errors.
+# However, those generators are best-pratice in Kubernetes environment and their results are tested well.
+# Thus, generated code is excluded from gosec scan.
+# Nested go modules are not supported by gosec (see https://github.com/securego/gosec/issues/501), so the ./hack folder
+# is excluded too. It does not contain productive code anyway.
+gosec -exclude-generated -exclude-dir=hack $gosec_report_parse_flags ./...

--- a/pkg/cmd/options.go
+++ b/pkg/cmd/options.go
@@ -73,7 +73,7 @@ func (o *PolicyFilterOptions) Complete() error {
 	if config.EgressFilter != nil && config.EgressFilter.DownloaderConfig != nil && o.OAuth2ConfigDir != "" {
 		secretData := &apisconfig.OAuth2Secret{}
 		filename := path.Join(o.OAuth2ConfigDir, constants.KeyClientID)
-		clientID, err := os.ReadFile(filename)
+		clientID, err := os.ReadFile(filename) // #nosec: G304 -- loading client id configuration from file is a feature. In reality files can be read from the pod's file system only.
 		if err != nil {
 			return fmt.Errorf("cannot read clientID from %s: %w", filename, err)
 		}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -24,7 +24,7 @@ const (
 	ImageEgressFilter = "egress-filter"
 
 	// FilterListSecretName name of the secret containing the egress filter list
-	FilterListSecretName = "egress-filter-list"
+	FilterListSecretName = "egress-filter-list" // #nosec G101 -- No credential.
 	// FilterNamespaceEnvName is the namespace of the extension deployment
 	FilterNamespaceEnvName = "FILTER_NAMESPACE"
 

--- a/pkg/controller/lifecycle/filterlistprovider.go
+++ b/pkg/controller/lifecycle/filterlistprovider.go
@@ -257,6 +257,7 @@ func (p *downloaderFilterListProvider) getAccessToken(endpoint string, oauth2sec
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
 					Certificates: []tls.Certificate{cert},
+					MinVersion:   tls.VersionTLS12,
 				},
 			},
 		}


### PR DESCRIPTION
/area networking
/area security
/area compliance
/kind enhancement

**What this PR does / why we need it**:

This PR introduces `gosec` for Static Application Security Testing at Gardener and should replace other code scanners.

It uses the default ruleset of `gosec` from gardener/gardener as introduced in https://github.com/gardener/gardener/pull/9959.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Until https://github.com/gardener/gardener/pull/10642 is in a gardener/gardener release there is a small workaround necessary, which will be removed afterwards.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`gosec` was introduced for Static Application Security Testing (SAST).
```
