### PR TITLE
Update base image to `debian12`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG EFFECTIVE_VERSION
 RUN make install EFFECTIVE_VERSION=$EFFECTIVE_VERSION
 
 ############# gardener-extension-shoot-networking-filter
-FROM  gcr.io/distroless/static-debian11:nonroot AS gardener-extension-shoot-networking-filter
+FROM  gcr.io/distroless/static-debian12:nonroot AS gardener-extension-shoot-networking-filter
 WORKDIR /
 
 COPY charts /charts
@@ -26,7 +26,7 @@ COPY --from=builder /go/bin/gardener-extension-shoot-networking-filter /gardener
 ENTRYPOINT ["/gardener-extension-shoot-networking-filter"]
 
 ############ gardener-runtime-networking-filter
-FROM  gcr.io/distroless/static-debian11:nonroot AS gardener-runtime-networking-filter
+FROM  gcr.io/distroless/static-debian12:nonroot AS gardener-runtime-networking-filter
 WORKDIR /
 
 COPY --from=builder /go/bin/gardener-runtime-networking-filter /gardener-runtime-networking-filter


### PR DESCRIPTION
**What this PR does / why we need it**:
Update base image from `debian11` to `debian12` to get current set of CA certificates.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update base image from `debian11` to `debian12`.
```
