### PR TITLE
Adapt location of operator kubeconfig for e2e test.

### DIFF
--- a/hack/test-e2e-operator-local.sh
+++ b/hack/test-e2e-operator-local.sh
@@ -26,7 +26,7 @@ trap '{
   export_artifacts "gardener-operator-local"
   make kind-operator-down
 }' EXIT
-export KUBECONFIG=$repo_root/gardener/example/provider-local/seed-operator/base/kubeconfig
+export KUBECONFIG=$repo_root/gardener/example/gardener-local/kind/operator/kubeconfig
 echo "<<<<<<<<<<<<<<<<<<<< kind-operator-up done"
 
 echo ">>>>>>>>>>>>>>>>>>>> operator-up"


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
