### PR TITLE
Drop support for Shoots with Kubernetes version <= 1.28

### DIFF
--- a/example/10-fake-shoot-controlplane.yaml
+++ b/example/10-fake-shoot-controlplane.yaml
@@ -173,7 +173,7 @@ spec:
         - --service-account-signing-key-file=/srv/kubernetes/service-account-key/id_rsa
         - --service-account-key-file=/srv/kubernetes/service-account-key-bundle/bundle.key
         - --v=2
-        image: registry.k8s.io/kube-apiserver:v1.28.2
+        image: registry.k8s.io/kube-apiserver:v1.32.0
         imagePullPolicy: IfNotPresent
         name: kube-apiserver
         ports:

--- a/example/30-cluster.yaml
+++ b/example/30-cluster.yaml
@@ -24,7 +24,7 @@ spec:
       dns:
         domain: foo.bar.example.com
       kubernetes:
-        version: 1.28.2
+        version: 1.32.0
       resources:
         - name: issuer-custom-eab-hmackey
           resourceRef:

--- a/test/e2e/local/common_test.go
+++ b/test/e2e/local/common_test.go
@@ -97,7 +97,7 @@ func createShoot(generateName string, blackholing bool, blockAddress string, use
 			SecretBindingName: ptr.To("local"),
 			CloudProfileName:  ptr.To("local"),
 			Kubernetes: gardencorev1beta1.Kubernetes{
-				Version: "1.27.1",
+				Version: "1.29.0",
 				Kubelet: &gardencorev1beta1.KubeletConfig{
 					SerializeImagePulls: ptr.To(false),
 					RegistryPullQPS:     ptr.To(int32(10)),

--- a/test/e2e/operator/common_test.go
+++ b/test/e2e/operator/common_test.go
@@ -104,7 +104,7 @@ func createShoot(generateName string, blackholing bool, blockAddress string, use
 			SecretBindingName: ptr.To("local"),
 			CloudProfileName:  ptr.To("local"),
 			Kubernetes: gardencorev1beta1.Kubernetes{
-				Version: "1.27.1",
+				Version: "1.29.0",
 				Kubelet: &gardencorev1beta1.KubeletConfig{
 					SerializeImagePulls: ptr.To(false),
 					RegistryPullQPS:     ptr.To(int32(10)),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/area quality

**What this PR does / why we need it**:
Drop support for Shoots, Seeds and Gardens with Kubernetes version <= 1.28.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/12409

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
`shoot-networking-filter` no longer supports Shoots with Кubernetes version <= 1.28.
```
